### PR TITLE
Remove Lua override from `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 * text=auto eol=lf
-*.luau linguist-language=Lua


### PR DESCRIPTION
GitHub now supports Luau syntax highlighting, so it is no longer necessary to force `.luau` files to be highlighted as Lua, which often has broken formatting.